### PR TITLE
Undefined name: from utils.torch_utils import get_region_boxes

### DIFF
--- a/src/models/yolov4_model.py
+++ b/src/models/yolov4_model.py
@@ -13,6 +13,7 @@ import torch.nn.functional as F
 sys.path.append('../')
 
 from models.yolo_layer import YoloLayer
+from utils.torch_utils import get_region_boxes
 
 
 class Mish(nn.Module):


### PR DESCRIPTION
`get_region_boxes()` is called on line 411 but it is never defined or imported which may lead to a NameError being raised at runtime.