### PR TITLE
Fix for pretrained models on different devices

### DIFF
--- a/src/test.py
+++ b/src/test.py
@@ -94,10 +94,13 @@ if __name__ == '__main__':
     model = create_model(configs)
     model.print_network()
     print('\n\n' + '-*=' * 30 + '\n\n')
+    
+    device_string = 'cpu' if configs.no_cuda else 'cuda:{}'.format(configs.gpu_idx)
+    
     assert os.path.isfile(configs.pretrained_path), "No file at {}".format(configs.pretrained_path)
-    model.load_state_dict(torch.load(configs.pretrained_path))
+    model.load_state_dict(torch.load(configs.pretrained_path, map_location=device_string))
 
-    configs.device = torch.device('cpu' if configs.no_cuda else 'cuda:{}'.format(configs.gpu_idx))
+    configs.device = torch.device(device_string)
     model = model.to(device=configs.device)
 
     out_cap = None


### PR DESCRIPTION
This PR intends to fix an issue where a change in the device used to train the model vs the device used to test would cause a runtime error when loading.

```
Traceback (most recent call last):
  File "test.py", line 101, in <module>
    model.load_state_dict(torch.load(configs.pretrained_path))
  File "/home/ben/.edm/envs/edm/lib/python3.6/site-packages/torch/serialization.py", line 593, in load
    return _legacy_load(opened_file, map_location, pickle_module, **pickle_load_args)
  File "/home/ben/.edm/envs/edm/lib/python3.6/site-packages/torch/serialization.py", line 773, in _legacy_load
    result = unpickler.load()
  File "/home/ben/.edm/envs/edm/lib/python3.6/site-packages/torch/serialization.py", line 729, in persistent_load
    deserialized_objects[root_key] = restore_location(obj, location)
  File "/home/ben/.edm/envs/edm/lib/python3.6/site-packages/torch/serialization.py", line 178, in default_restore_location
    result = fn(storage, location)
  File "/home/ben/.edm/envs/edm/lib/python3.6/site-packages/torch/serialization.py", line 154, in _cuda_deserialize
    device = validate_cuda_device(location)
  File "/home/ben/.edm/envs/edm/lib/python3.6/site-packages/torch/serialization.py", line 148, in validate_cuda_device
    device=device, device_count=torch.cuda.device_count()))
RuntimeError: Attempting to deserialize object on CUDA device 2 but torch.cuda.device_count() is 1. Please use torch.load with map_location to map your storages to an existing device.
```
As noted in the error the fix is to include map_location in the call to torch.load.
```python
    model.load_state_dict(torch.load(configs.pretrained_path, map_location=device_string))
```