### PR TITLE
Fix: Load a model for eval and test

### DIFF
--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -119,9 +119,10 @@ if __name__ == '__main__':
     # model.print_network()
     print('\n\n' + '-*=' * 30 + '\n\n')
     assert os.path.isfile(configs.pretrained_path), "No file at {}".format(configs.pretrained_path)
-    model.load_state_dict(torch.load(configs.pretrained_path))
 
     configs.device = torch.device('cpu' if configs.no_cuda else 'cuda:{}'.format(configs.gpu_idx))
+    model.load_state_dict(torch.load(configs.pretrained_path, map_location=configs.device))
+
     model = model.to(device=configs.device)
 
     model.eval()

--- a/src/test.py
+++ b/src/test.py
@@ -95,9 +95,10 @@ if __name__ == '__main__':
     model.print_network()
     print('\n\n' + '-*=' * 30 + '\n\n')
     assert os.path.isfile(configs.pretrained_path), "No file at {}".format(configs.pretrained_path)
-    model.load_state_dict(torch.load(configs.pretrained_path))
 
     configs.device = torch.device('cpu' if configs.no_cuda else 'cuda:{}'.format(configs.gpu_idx))
+    model.load_state_dict(torch.load(configs.pretrained_path, map_location=configs.device))
+
     model = model.to(device=configs.device)
 
     out_cap = None


### PR DESCRIPTION
Issue : When load a model for evaluating and testing by default, not get a device information from args.gpu_idx, but read it from the pre-train model(.pth).
In a yolov4 case, the device inforamtion is written "cuda:2". So, if have one graphic card, cause error.

Fix : When call torch.load(), I used a parameter(map_location).
map_location :  a function, torch.device, string or a dict specifying how to remap storage locations.