### PR TITLE
Correct LiDAR (3DBox) -> Camera (3DBox) calculation

### DIFF
--- a/src/data_process/transformation.py
+++ b/src/data_process/transformation.py
@@ -42,16 +42,12 @@ def camera_to_lidar(x, y, z, V2C=None, R0=None, P2=None):
     return tuple(p)
 
 
-def lidar_to_camera(x, y, z, V2C=None, R0=None, P2=None):
+def lidar_to_camera(x, y, z, h, V2C=None, R0=None, P2=None):
+    z = -h/2
     p = np.array([x, y, z, 1])
-    if V2C is None or R0 is None:
-        p = np.matmul(cnf.Tr_velo_to_cam, p)
-        p = np.matmul(cnf.R0, p)
-    else:
-        p = np.matmul(V2C, p)
-        p = np.matmul(R0, p)
-    p = p[0:3]
-    return tuple(p)
+    
+    p = np.dot(p, np.dot(V2C.T, R0.T))
+    return tuple(p[:3])
 
 
 def camera_to_lidar_point(points):
@@ -98,7 +94,7 @@ def lidar_to_camera_box(boxes, V2C=None, R0=None, P2=None):
     for box in boxes:
         x, y, z, h, w, l, rz = box
         (x, y, z), h, w, l, ry = lidar_to_camera(
-            x, y, z, V2C=V2C, R0=R0, P2=P2), h, w, l, -rz - np.pi / 2
+            x, y, z, h, V2C=V2C, R0=R0, P2=P2), h, w, l, -rz - np.pi / 2
         # ry = angle_in_limit(ry)
         ret.append([x, y, z, h, w, l, ry])
     return np.array(ret).reshape(-1, 7)


### PR DESCRIPTION
I used the two original methods `lidar_to_camera` and `lidar_to_camera_box` to calculate a label in camera frame. I realised that the y-value never matched the original label, even though I was using the appropriate calibration file instead of the mean values in `cnf.`.

```txt
Original camera label (h, w, l, x, y, z):  [1.48, 1.64, 3.59, -7.09, 1.75, 10.15, 1.57]
My approach output (x, y, z, h, w, l):     [-7.09, 1.75, 10.15, 1.48, 1.64, 3.59, 1.57]
Complex-YOLO output (x, y, z, h, w, l):    [-7.09, 1.01, 10.16, 1.48, 1.64, 3.59, 1.57]
```
Complex-YOLO uses the wrong matrix multiplication (order, no tranpose) and no height adjustment (reference point from box center to bottom)